### PR TITLE
Filter aggregator: add ne (not equal) and make it work on string data

### DIFF
--- a/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
@@ -19,121 +19,126 @@ package org.kairosdb.core.aggregator;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.annotation.FeatureComponent;
 import org.kairosdb.core.annotation.FeatureProperty;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.plugin.Aggregator;
 
 
 @FeatureComponent(
         name = "filter",
-		description = "Filters datapoints according to filter operation with a null data point."
+        description = "Filters datapoints according to filter operation with a null data point."
 )
-public class FilterAggregator implements Aggregator
-{
-	public enum FilterOperation
-	{
-		LTE, LT, GTE, GT, EQUAL
-	}
+public class FilterAggregator implements Aggregator {
+    public enum FilterOperation {
+        LTE, LT, GTE, GT, EQUAL, NE
+    }
 
-    public FilterAggregator()
-	{
-		m_threshold = 0.0;
-	}
+    public FilterAggregator() {
+        m_threshold = 0.0;
+    }
 
-	public FilterAggregator(FilterOperation filterop, double threshold)
-	{
-		m_filterop = filterop;
-		m_threshold = threshold;
-	}
+    public FilterAggregator(FilterOperation filterop, Object threshold) {
+        m_filterop = filterop;
+        m_threshold = threshold;
+    }
 
-	@FeatureProperty(
-			name = "filter_op",
-			label = "Filter operation",
-			description = "The operation performed for each data point.",
-			type = "enum",
-			options = {"lte", "lt", "gte", "gt", "equal"},
-			default_value = "equal"
-	)
-	private FilterOperation m_filterop;
+    @FeatureProperty(
+            name = "filter_op",
+            label = "Filter operation",
+            description = "The operation performed for each data point.",
+            type = "enum",
+            options = {"lte", "lt", "gte", "gt", "equal", "ne"},
+            default_value = "equal"
+    )
+    private FilterOperation m_filterop;
 
-	@FeatureProperty(
-			label = "Threshold",
-			description = "The value the operation is performed on. If the operation is lt, then a null data point is returned if the data point is less than the threshold."
-	)
-	private double m_threshold;
+    @FeatureProperty(
+            label = "Threshold",
+            description = "The value the operation is performed on. If the operation is lt, then a null data point is returned if the data point is less than the threshold."
+    )
+    private Object m_threshold;
 
-	/**
-	 Sets filter operation to apply to data points. Values can be LTE, LE, GTE, GT, or EQUAL.
+    /**
+     * Sets filter operation to apply to data points. Values can be LTE, LE, GTE, GT, NE, or EQUAL.
+     *
+     * @param filterop
+     */
+    public void setFilterOp(FilterOperation filterop) {
+        m_filterop = filterop;
+    }
 
-	 @param filterop
-	 */
-	public void setFilterOp(FilterOperation filterop)
-	{
-		m_filterop = filterop;
-	}
+    public void setThreshold(Object threshold) {
+        m_threshold = threshold;
+    }
 
-	public void setThreshold(double threshold)
-	{
-		m_threshold = threshold;
-	}
+    public DataPointGroup aggregate(DataPointGroup dataPointGroup) {
+        return new FilterDataPointAggregator(dataPointGroup);
+    }
 
-	public DataPointGroup aggregate(DataPointGroup dataPointGroup)
-	{
-		return new FilterDataPointAggregator(dataPointGroup);
-	}
+    public boolean canAggregate(String groupType) {
+        return true;
+    }
 
-	public boolean canAggregate(String groupType)
-	{
-		return true;
-	}
+    public String getAggregatedGroupType(String groupType) {
+        return groupType;
+    }
 
-	public String getAggregatedGroupType(String groupType)
-	{
-		return groupType;
-	}
+    private class FilterDataPointAggregator extends AggregatedDataPointGroupWrapper {
+        public FilterDataPointAggregator(DataPointGroup innerDataPointGroup) {
+            super(innerDataPointGroup);
+        }
 
-	private class FilterDataPointAggregator extends AggregatedDataPointGroupWrapper
-	{
-		public FilterDataPointAggregator(DataPointGroup innerDataPointGroup)
-		{
-			super(innerDataPointGroup);
-		}
 
-		public boolean hasNext()
-		{
-			boolean foundValidDp = false;
-			while (!foundValidDp && currentDataPoint != null)
-			{
-				double x0 = currentDataPoint.getDoubleValue();
-				if (m_filterop == FilterOperation.LTE && x0 <= m_threshold)
-					moveCurrentDataPoint();
-				else if (m_filterop == FilterOperation.LT && x0 < m_threshold)
-					moveCurrentDataPoint();
-				else if (m_filterop == FilterOperation.GTE && x0 >= m_threshold)
-					moveCurrentDataPoint();
-				else if (m_filterop == FilterOperation.GT && x0 > m_threshold)
-					moveCurrentDataPoint();
-				else if (m_filterop == FilterOperation.EQUAL && x0 == m_threshold)
-					moveCurrentDataPoint();
-				else
-					foundValidDp = true;
-			}
+        private <T> boolean filterOut(FilterOperation op, Comparable<T> value, T threshold) {
+            switch (op) {
+                case LTE:
+                    return value.compareTo(threshold) <= 0;
+                case LT:
+                    return value.compareTo(threshold) < 0;
+                case GTE:
+                    return value.compareTo(threshold) >= 0;
+                case GT:
+                    return value.compareTo(threshold) > 0;
+                case EQUAL:
+                    return value.compareTo(threshold) == 0;
+                case NE:
+                    return value.compareTo(threshold) != 0;
+                default:
+                    return false;
 
-			return foundValidDp;
-		}
+            }
+        }
 
-		public DataPoint next()
-		{
-			DataPoint ret = currentDataPoint;
-			moveCurrentDataPoint();
-			return ret;
-		}
+        public boolean hasNext() {
+            boolean foundValidDp = false;
+            while (!foundValidDp && currentDataPoint != null) {
+                boolean filterOutValue = false;
+                if (Double.class.isAssignableFrom(m_threshold.getClass())) {
+                    filterOutValue = filterOut(m_filterop, currentDataPoint.getDoubleValue(), (Double) m_threshold);
+                } else if (StringDataPoint.API_TYPE.equals(currentDataPoint.getApiDataType())) {
+                    filterOutValue = filterOut(m_filterop, ((StringDataPoint) currentDataPoint).getValue(), m_threshold.toString());
+                }
+                if (filterOutValue) {
+                    moveCurrentDataPoint();
+                } else {
+                    foundValidDp = true;
+                }
+            }
 
-		private void moveCurrentDataPoint()
-		{
-			if (hasNextInternal())
-				currentDataPoint = nextInternal();
-			else
-				currentDataPoint = null;
-		}
-	}
+            return foundValidDp;
+        }
+
+        public DataPoint next() {
+            DataPoint ret = currentDataPoint;
+            moveCurrentDataPoint();
+            return ret;
+        }
+
+        private void moveCurrentDataPoint() {
+            if (hasNextInternal())
+                currentDataPoint = nextInternal();
+            else
+                currentDataPoint = null;
+        }
+    }
 }

--- a/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
@@ -125,9 +125,8 @@ public class FilterAggregator implements Aggregator {
                         filterOutValue = filterOut(m_filterop, ((StringDataPoint) currentDataPoint).getValue(), m_threshold.toString());
                     }
                 } else {
-                    // when types are different, we filter consider the datapoint to be non-equal to the threshold, so we just check if the operation is non-equal
-                    // for all other operations the datapoint will NOT be filtered out
-                    filterOutValue = FilterOperation.NE.equals(m_filterop);
+                    // when types are different, we will filter out the data
+                    filterOutValue = true;
                 }
                 if (filterOutValue) {
                     moveCurrentDataPoint();

--- a/src/test/java/org/kairosdb/core/aggregator/FilterAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/FilterAggregatorTest.java
@@ -18,8 +18,9 @@ package org.kairosdb.core.aggregator;
 
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
+import org.kairosdb.core.datapoints.DoubleDataPoint;
 import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.testing.ListDataPointGroup;
 
@@ -216,6 +217,125 @@ public class FilterAggregatorTest
 		dp = results.next();
 		assertThat(dp.getTimestamp(), equalTo(6L));
 		assertThat(dp.getLongValue(), equalTo(25L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_NonEqualToFilter()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_ne_values");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(2, 20));
+		group.addDataPoint(new LongDataPoint(3, 15));
+		group.addDataPoint(new LongDataPoint(4, 30));
+		group.addDataPoint(new LongDataPoint(5, 10));
+		group.addDataPoint(new LongDataPoint(6, 25));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.NE);
+		filterAggregator.setThreshold(10.0);
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(1L));
+		assertThat(dp.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(5L));
+		assertThat(dp.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_StringFiltering()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_string_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new StringDataPoint(3, "gamma"));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new StringDataPoint(5, "alfa"));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.EQUAL);
+		filterAggregator.setThreshold("alfa");
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("beta"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("gamma"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("delta"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();assertThat(dp.getTimestamp(), equalTo(6L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("beta"));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_FilteringMixedTypes()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_mixed_types_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new LongDataPoint(3, 10L));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new DoubleDataPoint(5, 20.0));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.GTE);
+		filterAggregator.setThreshold(13.43543);
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(10.0));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_FilteringMixedTypesStringThreshold()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_mixed_types_string_thresh_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new LongDataPoint(3, 10L));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new DoubleDataPoint(5, 20.0));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.EQUAL);
+		filterAggregator.setThreshold("beta");
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("alfa"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("delta"));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -1144,6 +1144,7 @@
 			<select class="ui-widget aggregatorFilterOpValue"
 					style="margin-left: 10px;">
 				<option value="equal" selected="selected">EQUAL</option>
+				<option value="ne">NOT EQUAL</option>
 				<option value="lt">LT</option>
 				<option value="lte">LTE</option>
 				<option value="gt">GT</option>

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -158,17 +158,12 @@ function buildKairosDBQuery() {
 				}
 				metric.addScaleAggregator(scalingFactor);
 			}
-                        else if (name == 'filter')
-                        {
-                                var filterop = $(aggregator).find(".aggregatorFilterOpValue").val();
+      else if (name == 'filter')
+      {
+        var filterop = $(aggregator).find(".aggregatorFilterOpValue").val();
 				var threshold = $(aggregator).find(".aggregatorFilterThresholdValue").val();
-				if (!$.isNumeric(threshold))
-				{
-					showErrorMessage("filter threshold value must be a numeric value.");
-					return true;
-				}
-				metric.addFilterAggregator(filterop, threshold);
-                        }
+				metric.addFilterAggregator(filterop, $.isNumeric(threshold) ? parseFloat(threshold) : threshold);
+      }
 			else if (name == 'trim')
 			{
 				var agg = metric.addAggregator(name);


### PR DESCRIPTION
Added `ne` (not equal) operator 
Changes to make the aggregator work on string data

(sorry for all whitespace changes)

merged upstream by https://github.com/kairosdb/kairosdb/pull/582