### PR TITLE
Make first/last aggregator string compatible

### DIFF
--- a/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
@@ -70,7 +70,7 @@ public class FirstAggregator extends RangeAggregator {
             if (dataPointRange.hasNext()) {
                 DataPoint dataPoint = dataPointRange.next();
                 try {
-                    ret = Collections.singletonList(m_dataPointFactory.getFactoryForType(dataPoint.getApiDataType()).getDataPoint(returnTime, toDataInput(dataPoint)));
+                    ret = Collections.singletonList(m_dataPointFactory.getFactoryForDataStoreType(dataPoint.getDataStoreDataType()).getDataPoint(returnTime, toDataInput(dataPoint)));
                 } catch (IOException ioe) {
                     throw new RuntimeException(ioe);
                 }

--- a/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
@@ -17,65 +17,73 @@ package org.kairosdb.core.aggregator;
 
 import com.google.inject.Inject;
 import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.annotation.FeatureComponent;
-import org.kairosdb.core.datapoints.DoubleDataPointFactory;
+import org.kairosdb.util.KDataInput;
+import org.kairosdb.util.KDataOutput;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 
 /**
- Converts all longs to double. This will cause a loss of precision for very large long values.
+ * Converts all longs to double. This will cause a loss of precision for very large long values.
  */
 @FeatureComponent(
         name = "first",
-		description = "Returns the first value data point for the time range."
+        description = "Returns the first value data point for the time range."
 )
-public class FirstAggregator extends RangeAggregator
-{
-	private DoubleDataPointFactory m_dataPointFactory;
+public class FirstAggregator extends RangeAggregator {
+    private KairosDataPointFactory m_dataPointFactory;
 
-	@Inject
-	public FirstAggregator(DoubleDataPointFactory dataPointFactory)
-	{
-		m_dataPointFactory = dataPointFactory;
-	}
+    @Inject
+    public FirstAggregator(KairosDataPointFactory dataPointFactory) {
+        m_dataPointFactory = dataPointFactory;
+    }
 
-	@Override
-	public boolean canAggregate(String groupType)
-	{
-		return DataPoint.GROUP_NUMBER.equals(groupType);
-	}
+    @Override
+    public boolean canAggregate(String groupType) {
+        return true;
+    }
 
-	@Override
-	public String getAggregatedGroupType(String groupType)
-	{
-		return m_dataPointFactory.getGroupType();
-	}
+    @Override
+    public String getAggregatedGroupType(String groupType) {
+        return groupType;
+    }
 
-	@Override
-	protected RangeSubAggregator getSubAggregator()
-	{
-		return (new FirstDataPointAggregator());
-	}
+    @Override
+    protected RangeSubAggregator getSubAggregator() {
+        return (new FirstDataPointAggregator());
+    }
 
-	private class FirstDataPointAggregator implements RangeSubAggregator
-	{
-		@Override
-		public Iterable<DataPoint> getNextDataPoints(long returnTime, Iterator<DataPoint> dataPointRange)
-		{
-			Iterable<DataPoint> ret;
-			if (dataPointRange.hasNext())
-				ret = Collections.singletonList(m_dataPointFactory.createDataPoint(returnTime, dataPointRange.next().getDoubleValue()));
-			else
-				ret = Collections.emptyList();
+    private DataInput toDataInput(DataPoint dataPoint) throws IOException {
+        KDataOutput output = new KDataOutput();
+        dataPoint.writeValueToBuffer(output);
+        return KDataInput.createInput(output.getBytes());
+    }
 
-			//Chew up the rest of the data points in range
-			while (dataPointRange.hasNext())
-			{
-				dataPointRange.next();
-			}
+    private class FirstDataPointAggregator implements RangeSubAggregator {
+        @Override
+        public Iterable<DataPoint> getNextDataPoints(long returnTime, Iterator<DataPoint> dataPointRange) {
+            Iterable<DataPoint> ret;
+            if (dataPointRange.hasNext()) {
+                DataPoint dataPoint = dataPointRange.next();
+                try {
+                    ret = Collections.singletonList(m_dataPointFactory.getFactoryForType(dataPoint.getApiDataType()).getDataPoint(returnTime, toDataInput(dataPoint)));
+                } catch (IOException ioe) {
+                    throw new RuntimeException(ioe);
+                }
 
-			return ret;
-		}
-	}
+            } else
+                ret = Collections.emptyList();
+
+            //Chew up the rest of the data points in range
+            while (dataPointRange.hasNext()) {
+                dataPointRange.next();
+            }
+
+            return ret;
+        }
+    }
 }

--- a/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
@@ -78,7 +78,7 @@ public class LastAggregator extends RangeAggregator {
 				}
 
                 try {
-                    return Collections.singletonList(m_dataPointFactory.getFactoryForType(lastDp.getApiDataType()).getDataPoint(retTime, toDataInput(lastDp)));
+                    return Collections.singletonList(m_dataPointFactory.getFactoryForDataStoreType(lastDp.getDataStoreDataType()).getDataPoint(retTime, toDataInput(lastDp)));
                 } catch (IOException ioe) {
                     throw new RuntimeException(ioe);
                 }

--- a/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
@@ -17,74 +17,74 @@ package org.kairosdb.core.aggregator;
 
 import com.google.inject.Inject;
 import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.annotation.FeatureComponent;
-import org.kairosdb.core.datapoints.DoubleDataPointFactory;
+import org.kairosdb.util.KDataInput;
+import org.kairosdb.util.KDataOutput;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 
 /**
- Converts all longs to double. This will cause a loss of precision for very large long values.
+ * Converts all longs to double. This will cause a loss of precision for very large long values.
  */
 @FeatureComponent(
         name = "last",
-		description = "Returns the last value data point for the time range."
+        description = "Returns the last value data point for the time range."
 )
-public class LastAggregator extends RangeAggregator
-{
-	private DoubleDataPointFactory m_dataPointFactory;
+public class LastAggregator extends RangeAggregator {
+    private KairosDataPointFactory m_dataPointFactory;
 
-	@Inject
-	public LastAggregator(DoubleDataPointFactory dataPointFactory)
-	{
-		m_dataPointFactory = dataPointFactory;
-	}
+    @Inject
+    public LastAggregator(KairosDataPointFactory dataPointFactory) {
+        m_dataPointFactory = dataPointFactory;
+    }
 
-	@Override
-	public boolean canAggregate(String groupType)
-	{
-		return DataPoint.GROUP_NUMBER.equals(groupType);
-	}
+    @Override
+    public boolean canAggregate(String groupType) {
+        return true;
+    }
 
-	@Override
-	public String getAggregatedGroupType(String groupType)
-	{
-		return m_dataPointFactory.getGroupType();
-	}
+    @Override
+    public String getAggregatedGroupType(String groupType) {
+        return groupType;
+    }
 
-	@Override
-	protected RangeSubAggregator getSubAggregator()
-	{
-		return (new LastDataPointAggregator());
-	}
+    @Override
+    protected RangeSubAggregator getSubAggregator() {
+        return (new LastDataPointAggregator());
+    }
 
-	private class LastDataPointAggregator implements RangeSubAggregator
-	{
-		@Override
-		public Iterable<DataPoint> getNextDataPoints(long returnTime, Iterator<DataPoint> dataPointRange)
-		{
-			Double last = null;
-			Long lastTime = 0L;
-			while (dataPointRange.hasNext())
-			{
-				final DataPoint dp = dataPointRange.next();
-				if (dp.isDouble())
-				{
-					last = dp.getDoubleValue();
-					lastTime = dp.getTimestamp();
+    private DataInput toDataInput(DataPoint dataPoint) throws IOException {
+        KDataOutput output = new KDataOutput();
+        dataPoint.writeValueToBuffer(output);
+        return KDataInput.createInput(output.getBytes());
+    }
+
+    private class LastDataPointAggregator implements RangeSubAggregator {
+        @Override
+        public Iterable<DataPoint> getNextDataPoints(long returnTime, Iterator<DataPoint> dataPointRange) {
+            DataPoint lastDp = null;
+            while (dataPointRange.hasNext()) {
+                lastDp = dataPointRange.next();
+            }
+
+            if (lastDp != null) {
+                long retTime = returnTime;
+                if (!m_alignStartTime && !m_alignEndTime) {
+					retTime = lastDp.getTimestamp();
 				}
-			}
 
-			if (last != null)
-			{
-				long retTime = returnTime;
-				if (!m_alignStartTime && !m_alignEndTime)
-					retTime = lastTime;
+                try {
+                    return Collections.singletonList(m_dataPointFactory.getFactoryForType(lastDp.getApiDataType()).getDataPoint(retTime, toDataInput(lastDp)));
+                } catch (IOException ioe) {
+                    throw new RuntimeException(ioe);
+                }
+            }
 
-				return Collections.singletonList(m_dataPointFactory.createDataPoint(retTime, last));
-			}
-
-			return Collections.emptyList();
-		}
-	}
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/test/java/org/kairosdb/core/aggregator/FirstAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/FirstAggregatorTest.java
@@ -18,35 +18,30 @@ package org.kairosdb.core.aggregator;
 import org.junit.Before;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
-import org.kairosdb.core.datapoints.LegacyLongDataPoint;
-import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.GuiceKairosDataPointFactory;
+import org.kairosdb.core.TestDataPointFactory;
+import org.kairosdb.core.datapoints.*;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.testing.ListDataPointGroup;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-public class FirstAggregatorTest
-{
+public class FirstAggregatorTest {
 	private FirstAggregator aggregator;
 
 	@Before
-	public void setup()
-	{
-		aggregator = new FirstAggregator(new DoubleDataPointFactoryImpl());
+	public void setup() {
+		aggregator = new FirstAggregator(new TestDataPointFactory());
 	}
 
 	@Test(expected = NullPointerException.class)
-	public void test_nullSet_invalid()
-	{
+	public void test_nullSet_invalid() {
 		aggregator.aggregate(null);
 	}
 
 	@Test
-	public void test_longValues()
-	{
+	public void test_longValues() {
 		ListDataPointGroup group = new ListDataPointGroup("group");
 		group.addDataPoint(new LongDataPoint(1, 10));
 		group.addDataPoint(new LongDataPoint(1, 20));
@@ -74,8 +69,7 @@ public class FirstAggregatorTest
 	}
 
 	@Test
-	public void test_doubleValues()
-	{
+	public void test_doubleValues() {
 		ListDataPointGroup group = new ListDataPointGroup("group");
 		group.addDataPoint(new DoubleDataPoint(1, 10.0));
 		group.addDataPoint(new DoubleDataPoint(1, 20.3));
@@ -103,8 +97,7 @@ public class FirstAggregatorTest
 	}
 
 	@Test
-	public void test_mixedTypeValues()
-	{
+	public void test_mixedTypeValues() {
 		ListDataPointGroup group = new ListDataPointGroup("group");
 		group.addDataPoint(new DoubleDataPoint(1, 10.0));
 		group.addDataPoint(new DoubleDataPoint(1, 20.3));
@@ -112,7 +105,9 @@ public class FirstAggregatorTest
 		group.addDataPoint(new LongDataPoint(2, 1));
 		group.addDataPoint(new DoubleDataPoint(2, 3.2));
 		group.addDataPoint(new DoubleDataPoint(2, 5.0));
+		group.addDataPoint(new StringDataPoint(3, "25.3"));
 		group.addDataPoint(new DoubleDataPoint(3, 25.1));
+		group.addDataPoint(new DoubleDataPoint(4, 23.4));
 
 		DataPointGroup results = aggregator.aggregate(group);
 
@@ -126,14 +121,17 @@ public class FirstAggregatorTest
 
 		dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(3L));
-		assertThat(dataPoint.getDoubleValue(), equalTo(25.1));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("25.3"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(4L));
+		assertThat(dataPoint.getDoubleValue(), equalTo(23.4));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}
 
 	@Test
-	public void test_withNegativeValues()
-	{
+	public void test_withNegativeValues() {
 		ListDataPointGroup group = new ListDataPointGroup("group");
 		group.addDataPoint(new DoubleDataPoint(1, -10.0));
 		group.addDataPoint(new DoubleDataPoint(1, -20.3));
@@ -162,8 +160,7 @@ public class FirstAggregatorTest
 	}
 
 	@Test
-	public void test_legacyLongValues()
-	{
+	public void test_legacyLongValues() {
 		ListDataPointGroup group = new ListDataPointGroup("group");
 		group.addDataPoint(new LegacyLongDataPoint(1, 10));
 		group.addDataPoint(new LegacyLongDataPoint(1, 20));
@@ -178,6 +175,34 @@ public class FirstAggregatorTest
 		DataPoint dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(1L));
 		assertThat(dataPoint.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_stringValues() {
+		ListDataPointGroup group = new ListDataPointGroup("group");
+		group.addDataPoint(new StringDataPoint(1, "a"));
+		group.addDataPoint(new StringDataPoint(1, "b"));
+		group.addDataPoint(new StringDataPoint(1, "c"));
+		group.addDataPoint(new StringDataPoint(2, "d"));
+		group.addDataPoint(new StringDataPoint(2, "e"));
+		group.addDataPoint(new StringDataPoint(2, "f"));
+		group.addDataPoint(new StringDataPoint(3, "g"));
+
+		DataPointGroup results = aggregator.aggregate(group);
+
+		DataPoint dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("a"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("d"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("g"));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}

--- a/src/test/java/org/kairosdb/core/aggregator/LastAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/LastAggregatorTest.java
@@ -18,10 +18,11 @@ package org.kairosdb.core.aggregator;
 import org.junit.Before;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.TestDataPointFactory;
 import org.kairosdb.core.datapoints.DoubleDataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
 import org.kairosdb.core.datapoints.LegacyLongDataPoint;
 import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.core.datastore.TimeUnit;
 import org.kairosdb.testing.ListDataPointGroup;
@@ -36,7 +37,7 @@ public class LastAggregatorTest
 	@Before
 	public void setup()
 	{
-		aggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		aggregator = new LastAggregator(new TestDataPointFactory());
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -114,6 +115,8 @@ public class LastAggregatorTest
 		group.addDataPoint(new DoubleDataPoint(2, 3.2));
 		group.addDataPoint(new DoubleDataPoint(2, 5.0));
 		group.addDataPoint(new DoubleDataPoint(3, 25.1));
+		group.addDataPoint(new StringDataPoint(3, "23.1"));
+		group.addDataPoint(new DoubleDataPoint(4, 25.1));
 
 		DataPointGroup results = aggregator.aggregate(group);
 
@@ -127,6 +130,10 @@ public class LastAggregatorTest
 
 		dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("23.1"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(4L));
 		assertThat(dataPoint.getDoubleValue(), equalTo(25.1));
 
 		assertThat(results.hasNext(), equalTo(false));
@@ -184,6 +191,34 @@ public class LastAggregatorTest
 	}
 
 	@Test
+	public void test_stringValues() {
+		ListDataPointGroup group = new ListDataPointGroup("group");
+		group.addDataPoint(new StringDataPoint(1, "a"));
+		group.addDataPoint(new StringDataPoint(1, "b"));
+		group.addDataPoint(new StringDataPoint(1, "c"));
+		group.addDataPoint(new StringDataPoint(2, "d"));
+		group.addDataPoint(new StringDataPoint(2, "e"));
+		group.addDataPoint(new StringDataPoint(2, "f"));
+		group.addDataPoint(new StringDataPoint(3, "g"));
+
+		DataPointGroup results = aggregator.aggregate(group);
+
+		DataPoint dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("c"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("f"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("g"));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
 	public void test_alignStartOn()
 	{
 		ListDataPointGroup group = new ListDataPointGroup("group");
@@ -196,7 +231,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator(new TestDataPointFactory());
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignStartTime(true);
 		DataPointGroup results = lastAggregator.aggregate(group);
@@ -225,7 +260,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator(new TestDataPointFactory());
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignStartTime(false);
 		DataPointGroup results = lastAggregator.aggregate(group);
@@ -254,7 +289,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator(new TestDataPointFactory());
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignEndTime(true);
 		DataPointGroup results = lastAggregator.aggregate(group);

--- a/src/test/java/org/kairosdb/core/aggregator/TestAggregatorFactory.java
+++ b/src/test/java/org/kairosdb/core/aggregator/TestAggregatorFactory.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.kairosdb.core.KairosDataPointFactory;
+import org.kairosdb.core.TestDataPointFactory;
 import org.kairosdb.core.annotation.Feature;
 import org.kairosdb.core.annotation.FeatureComponent;
 import org.kairosdb.core.datapoints.DoubleDataPointFactory;
@@ -63,6 +65,7 @@ public class TestAggregatorFactory implements FeatureProcessingFactory<Aggregato
 			@Override
 			protected void configure()
 			{
+				bind(KairosDataPointFactory.class).to(TestDataPointFactory.class);
 				bind(DoubleDataPointFactory.class).to(DoubleDataPointFactoryImpl.class);
 				bind(FilterEventBus.class).toInstance(new FilterEventBus(new EventBusConfiguration(new Properties())));
 


### PR DESCRIPTION
Made first and last aggregator work on string datapoints

merged upstream by https://github.com/kairosdb/kairosdb/pull/581