### PR TITLE
WPPM-2808 fix serialization of IngestionTimestampDatapoint for CachedSearchResult

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,5 +34,5 @@ jobs:
     - name: compile and test
       env:
         CLASSPATH: tools/tablesaw-1.2.8.jar
-      run: java make ivy-retrieve;java make clean test-all
+      run: java make ivy-retrieve;java make clean test-all;mvn clean test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         distribution: 'temurin'
     - name: compile and test
       env:
+        CASSANDRA_HOST: localhost
         CLASSPATH: tools/tablesaw-1.2.8.jar
       run: java make ivy-retrieve;java make clean test-all;mvn clean test
 

--- a/src/main/java/org/kairosdb/core/datastore/CachedSearchResult.java
+++ b/src/main/java/org/kairosdb/core/datastore/CachedSearchResult.java
@@ -18,6 +18,7 @@ package org.kairosdb.core.datastore;
 
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.KairosDataPointFactory;
+import org.kairosdb.core.datapoints.IngestionTimestampDataPoint;
 import org.kairosdb.util.BufferedDataInputStream;
 import org.kairosdb.util.BufferedDataOutputStream;
 import org.kairosdb.util.KDataInputStream;
@@ -284,6 +285,7 @@ public class CachedSearchResult implements SearchResult
 		private final String m_dataType;
 		private final Map<String, String> m_tags;
 		private final List<DataPoint> m_dataPoints;
+		private boolean m_hasIngestionTimestamp = false;
 
 		public CachedDatapointWriter(String type, Map<String, String> tags)
 		{
@@ -296,6 +298,10 @@ public class CachedSearchResult implements SearchResult
 		public void addDataPoint(DataPoint datapoint) throws IOException
 		{
 			m_dataPoints.add(datapoint);
+			if (datapoint instanceof IngestionTimestampDataPoint)
+			{
+				m_hasIngestionTimestamp = true;
+			}
 			m_memoryMonitor.checkMemoryAndThrowException();
 		}
 
@@ -313,14 +319,34 @@ public class CachedSearchResult implements SearchResult
 					openCacheFile();
 
 				long curPosition = m_dataOutputStream.getPosition();
-				m_currentFilePositionMarker = new FilePositionMarker(curPosition, m_tags, m_dataType);
+				m_currentFilePositionMarker = new FilePositionMarker(curPosition, m_tags, m_dataType, m_hasIngestionTimestamp);
 				m_dataPointSets.add(m_currentFilePositionMarker);
 
 
 				for (DataPoint dataPoint : m_dataPoints)
 				{
 					m_dataOutputStream.writeLong(dataPoint.getTimestamp());
-					dataPoint.writeValueToBuffer(m_dataOutputStream);
+
+					if (m_hasIngestionTimestamp)
+					{
+						if (dataPoint instanceof IngestionTimestampDataPoint)
+						{
+							m_dataOutputStream.writeBoolean(true); // has ingestion timestamp
+							IngestionTimestampDataPoint itdp = (IngestionTimestampDataPoint) dataPoint;
+							m_dataOutputStream.writeLong(itdp.getIngestionTimestamp());
+							itdp.writeValueToBuffer(m_dataOutputStream);
+						}
+						else
+						{
+							m_dataOutputStream.writeBoolean(false); // no ingestion timestamp
+							dataPoint.writeValueToBuffer(m_dataOutputStream);
+						}
+					}
+					else
+					{
+						// Old format - no per-data-point flags
+						dataPoint.writeValueToBuffer(m_dataOutputStream);
+					}
 
 					m_currentFilePositionMarker.incrementDataPointCount();
 				}
@@ -351,6 +377,7 @@ public class CachedSearchResult implements SearchResult
 		private Map<String, String> m_tags;
 		private String m_dataType;
 		private int m_dataPointCount;
+		private boolean m_hasIngestionTimestamp;
 
 
 		public FilePositionMarker()
@@ -360,14 +387,16 @@ public class CachedSearchResult implements SearchResult
 			m_tags = new HashMap<String, String>();
 			m_dataType = null;
 			m_dataPointCount = 0;
+			m_hasIngestionTimestamp = false;
 		}
 
 		public FilePositionMarker(long startPosition, Map<String, String> tags,
-				String dataType)
+				String dataType, boolean hasIngestionTimestamp)
 		{
 			m_startPosition = startPosition;
 			m_tags = tags;
 			m_dataType = dataType;
+			m_hasIngestionTimestamp = hasIngestionTimestamp;
 		}
 
 		public void setEndPosition(long endPosition)
@@ -394,7 +423,7 @@ public class CachedSearchResult implements SearchResult
 		public CachedDataPointRow iterator()
 		{
 			return (new CachedDataPointRow(m_tags, m_startPosition, m_endPosition,
-					m_dataType, m_dataPointCount));
+					m_dataType, m_dataPointCount, m_hasIngestionTimestamp));
 		}
 
 		@Override
@@ -404,6 +433,7 @@ public class CachedSearchResult implements SearchResult
 			out.writeLong(m_endPosition);
 			out.writeInt(m_dataPointCount);
 			out.writeObject(m_dataType);
+			out.writeBoolean(m_hasIngestionTimestamp);
 			out.writeInt(m_tags.size());
 			for (String s : m_tags.keySet())
 			{
@@ -419,6 +449,7 @@ public class CachedSearchResult implements SearchResult
 			m_endPosition = in.readLong();
 			m_dataPointCount = in.readInt();
 			m_dataType = (String)in.readObject();
+			m_hasIngestionTimestamp = in.readBoolean();
 			//m_dataPointCount = (int)((m_endPosition - m_startPosition) / DATA_POINT_SIZE);
 
 			int tagCount = in.readInt();
@@ -440,10 +471,11 @@ public class CachedSearchResult implements SearchResult
 		private Map<String, String> m_tags;
 		private final String m_dataType;
 		private final int m_dataPointCount;
+		private final boolean m_hasIngestionTimestamp;
 		private int m_dataPointsRead = 0;
 
 		public CachedDataPointRow(Map<String, String> tags,
-				long startPosition, long endPostition, String dataType, int dataPointCount)
+				long startPosition, long endPostition, String dataType, int dataPointCount, boolean hasIngestionTimestamp)
 		{
 			m_currentPosition = startPosition;
 			m_endPostition = endPostition;
@@ -451,6 +483,7 @@ public class CachedSearchResult implements SearchResult
 			m_tags = tags;
 			m_dataType = dataType;
 			m_dataPointCount = dataPointCount;
+			m_hasIngestionTimestamp = hasIngestionTimestamp;
 		}
 
 		private void allocateReadBuffer()
@@ -482,7 +515,24 @@ public class CachedSearchResult implements SearchResult
 
 				long timestamp = m_readBuffer.readLong();
 
-				ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+				if (m_hasIngestionTimestamp)
+				{
+					boolean hasIngestionTimestamp = m_readBuffer.readBoolean();
+					if (hasIngestionTimestamp)
+					{
+						long ingestionTimestamp = m_readBuffer.readLong();
+						DataPoint baseDataPoint = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+						ret = new IngestionTimestampDataPoint(baseDataPoint, ingestionTimestamp);
+					}
+					else
+					{
+						ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+					}
+				}
+				else
+				{
+					ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+				}
 
 			}
 			catch (IOException ioe)

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -657,8 +657,7 @@ public class CassandraDatastore implements Datastore, ProcessorHandler, KairosMe
 						Long ingestionTimestamp = null;
 						if (m_returnIngestionTimestamp && row.getColumnDefinitions().size() > 2)
 						{
-							// WRITETIME returns timestamp in microseconds, convert to milliseconds
-							ingestionTimestamp = row.getLong(2) / 1000;
+							ingestionTimestamp = row.getLong(2);
 						}
 
 						DataPoint dataPoint;
@@ -777,13 +776,13 @@ public class CassandraDatastore implements Datastore, ProcessorHandler, KairosMe
 			{
 				if (query.getOrder() == Order.ASC)
 				{
-					boundStatement = returnIngestionTimestamp ? 
+					boundStatement = returnIngestionTimestamp ?
 						new BoundStatement(cluster.psDataPointsQueryAscLimitWithWritetime) :
 						new BoundStatement(cluster.psDataPointsQueryAscLimit);
 				}
 				else
 				{
-					boundStatement = returnIngestionTimestamp ? 
+					boundStatement = returnIngestionTimestamp ?
 						new BoundStatement(cluster.psDataPointsQueryDescLimitWithWritetime) :
 						new BoundStatement(cluster.psDataPointsQueryDescLimit);
 				}
@@ -792,13 +791,13 @@ public class CassandraDatastore implements Datastore, ProcessorHandler, KairosMe
 			{
 				if (query.getOrder() == Order.ASC)
 				{
-					boundStatement = returnIngestionTimestamp ? 
+					boundStatement = returnIngestionTimestamp ?
 						new BoundStatement(cluster.psDataPointsQueryAscWithWritetime) :
 						new BoundStatement(cluster.psDataPointsQueryAsc);
 				}
 				else
 				{
-					boundStatement = returnIngestionTimestamp ? 
+					boundStatement = returnIngestionTimestamp ?
 						new BoundStatement(cluster.psDataPointsQueryDescWithWritetime) :
 						new BoundStatement(cluster.psDataPointsQueryDesc);
 				}

--- a/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.TestDataPointFactory;
+import org.kairosdb.core.datapoints.IngestionTimestampDataPoint;
 import org.kairosdb.core.datapoints.LegacyDataPointFactory;
 import org.kairosdb.core.datapoints.LegacyDoubleDataPoint;
 import org.kairosdb.core.datapoints.LegacyLongDataPoint;
@@ -182,6 +183,109 @@ public class CachedSearchResultTest
 
 		assertThat(count, equalTo(numberOfDataPoints));
 
+	}
+
+	@Test
+	public void test_IngestionTimestampDataPoint_Preservation() throws IOException
+	{
+		String tempFile = System.getProperty("java.io.tmpdir") + "/baseFile_ingestion";
+		CachedSearchResult csResult =
+				CachedSearchResult.createCachedSearchResult("metric_ingestion", tempFile, dataPointFactory, true);
+
+		long now = System.currentTimeMillis();
+		long ingestionTime = now + 5000; // 5 seconds later
+
+		SortedMap<String, String> tags = new TreeMap<>();
+		tags.put("host", "A");
+		tags.put("client", "foo");
+		QueryCallback.DataPointWriter dataPointWriter = csResult.startDataPointSet(LegacyDataPointFactory.DATASTORE_TYPE, tags);
+
+		// Add regular data points
+		dataPointWriter.addDataPoint(new LegacyLongDataPoint(now, 42));
+
+		// Add IngestionTimestampDataPoint
+		LegacyLongDataPoint baseDataPoint = new LegacyLongDataPoint(now + 1, 43);
+		IngestionTimestampDataPoint ingestionDataPoint = new IngestionTimestampDataPoint(baseDataPoint, ingestionTime);
+		dataPointWriter.addDataPoint(ingestionDataPoint);
+
+		// Add another regular data point
+		dataPointWriter.addDataPoint(new LegacyDoubleDataPoint(now + 2, 44.1));
+
+		dataPointWriter.close();
+
+		List<DataPointRow> rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		DataPointRow row = rows.get(0);
+
+		// Verify first data point (regular)
+		assertThat(row.hasNext(), equalTo(true));
+		DataPoint dp1 = row.next();
+		assertThat(dp1.isLong(), equalTo(true));
+		assertThat(dp1.getLongValue(), equalTo(42L));
+		assertThat(dp1.getTimestamp(), equalTo(now));
+		assertThat(dp1 instanceof IngestionTimestampDataPoint, equalTo(false));
+
+		// Verify second data point (IngestionTimestampDataPoint)
+		assertThat(row.hasNext(), equalTo(true));
+		DataPoint dp2 = row.next();
+		assertThat(dp2 instanceof IngestionTimestampDataPoint, equalTo(true));
+		IngestionTimestampDataPoint itdp = (IngestionTimestampDataPoint) dp2;
+		assertThat(itdp.isLong(), equalTo(true));
+		assertThat(itdp.getLongValue(), equalTo(43L));
+		assertThat(itdp.getTimestamp(), equalTo(now + 1));
+		assertThat(itdp.getIngestionTimestamp(), equalTo(ingestionTime));
+
+		// Verify third data point (regular)
+		assertThat(row.hasNext(), equalTo(true));
+		DataPoint dp3 = row.next();
+		assertThat(dp3.isDouble(), equalTo(true));
+		assertThat(dp3.getDoubleValue(), equalTo(44.1));
+		assertThat(dp3.getTimestamp(), equalTo(now + 2));
+		assertThat(dp3 instanceof IngestionTimestampDataPoint, equalTo(false));
+
+		assertThat(row.hasNext(), equalTo(false));
+
+		row.close();
+		csResult.close();
+
+		// Re-open cached file and verify the data is preserved correctly
+		csResult = CachedSearchResult.openCachedSearchResult("metric_ingestion", tempFile, 100, dataPointFactory, true);
+		rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		row = rows.get(0);
+
+		// Verify first data point (regular) after reload
+		assertThat(row.hasNext(), equalTo(true));
+		dp1 = row.next();
+		assertThat(dp1.isLong(), equalTo(true));
+		assertThat(dp1.getLongValue(), equalTo(42L));
+		assertThat(dp1.getTimestamp(), equalTo(now));
+		assertThat(dp1 instanceof IngestionTimestampDataPoint, equalTo(false));
+
+		// Verify second data point (IngestionTimestampDataPoint) after reload
+		assertThat(row.hasNext(), equalTo(true));
+		dp2 = row.next();
+		assertThat(dp2 instanceof IngestionTimestampDataPoint, equalTo(true));
+		itdp = (IngestionTimestampDataPoint) dp2;
+		assertThat(itdp.isLong(), equalTo(true));
+		assertThat(itdp.getLongValue(), equalTo(43L));
+		assertThat(itdp.getTimestamp(), equalTo(now + 1));
+		assertThat(itdp.getIngestionTimestamp(), equalTo(ingestionTime));
+
+		// Verify third data point (regular) after reload
+		assertThat(row.hasNext(), equalTo(true));
+		dp3 = row.next();
+		assertThat(dp3.isDouble(), equalTo(true));
+		assertThat(dp3.getDoubleValue(), equalTo(44.1));
+		assertThat(dp3.getTimestamp(), equalTo(now + 2));
+		assertThat(dp3 instanceof IngestionTimestampDataPoint, equalTo(false));
+
+		assertThat(row.hasNext(), equalTo(false));
+
+		row.close();
+		csResult.close();
 	}
 
 	private void assertValues(DataPointRow dataPoints, Number... numbers)

--- a/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
@@ -49,8 +49,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 
 public class CassandraDatastoreTest extends DatastoreTestHelper
@@ -952,12 +951,10 @@ public class CassandraDatastoreTest extends DatastoreTestHelper
 		Thread.sleep(2000);  // Wait for data to be written
 
 		// Test direct call to CassandraDatastore with ingestion timestamp
-		DatastoreMetricQueryImpl directQuery = new DatastoreMetricQueryImpl(testMetric,
-				HashMultimap.create(), dataPointTime - 1000, dataPointTime + 1000);
-		directQuery.setReturnIngestionTimestamp(true);
-
+        QueryMetric queryMetric = new QueryMetric(dataPointTime - 1000,dataPointTime + 1000,0,testMetric);
+        queryMetric.setReturnIngestionTimestamp(true);
 		CachedSearchResult searchResult = createCache("ingestion_timestamp_direct_test");
-		s_datastore.queryDatabase(directQuery, searchResult);
+		s_datastore.queryDatabase(queryMetric, searchResult);
 		List<DataPointRow> rows = searchResult.getRows();
 
 		assertThat("Should have at least one row", rows.size(), greaterThan(0));
@@ -972,28 +969,17 @@ public class CassandraDatastoreTest extends DatastoreTestHelper
 		assertThat(dp.getLongValue(), equalTo(123L));
 
 		// Verify the feature works correctly
-		// NOTE: Currently the feature appears not to be fully working, so we test both scenarios
-		if (dp instanceof org.kairosdb.core.datapoints.IngestionTimestampDataPoint)
-		{
-			// Success case: feature is working
-			org.kairosdb.core.datapoints.IngestionTimestampDataPoint timestampedDp =
-				(org.kairosdb.core.datapoints.IngestionTimestampDataPoint) dp;
-			long ingestionTimestamp = timestampedDp.getIngestionTimestamp();
+        assertTrue(dp instanceof org.kairosdb.core.datapoints.IngestionTimestampDataPoint);
 
-			// Ingestion timestamp should be reasonable
-			assertThat("Ingestion timestamp should be after data point time",
-				ingestionTimestamp, greaterThan(dataPointTime - 1000L));
-			assertThat("Ingestion timestamp should not be too far in the future",
-				ingestionTimestamp, org.hamcrest.Matchers.lessThan(System.currentTimeMillis() + 10000L));
-		}
-		else
-		{
-			// Current behavior: feature doesn't return IngestionTimestampDataPoint
-			// This test documents the current state and will fail when the feature is fixed
-			assertThat("Feature should return IngestionTimestampDataPoint when returnIngestionTimestamp=true. " +
-				"If this fails, the feature has been implemented successfully!",
-				dp instanceof org.kairosdb.core.datapoints.IngestionTimestampDataPoint, equalTo(false));
-		}
+        org.kairosdb.core.datapoints.IngestionTimestampDataPoint timestampedDp =
+            (org.kairosdb.core.datapoints.IngestionTimestampDataPoint) dp;
+        long ingestionTimestamp = timestampedDp.getIngestionTimestamp();
+
+        // Ingestion timestamp should be reasonable
+        assertThat("Ingestion timestamp should be after data point time",
+            ingestionTimestamp, greaterThan(dataPointTime - 1000L));
+        assertThat("Ingestion timestamp should not be too far in the future",
+            ingestionTimestamp, org.hamcrest.Matchers.lessThan(System.currentTimeMillis() + 10000L));
 
 		searchResult.close();
 	}


### PR DESCRIPTION
IngestionTimestampDatapoint was not serialized to the CachedSearchResult which is used during querying/returning results