### PR TITLE
fix: WPPM-2938 StringDataPoint serialization for large strings and Unicode emojis via LongUTFWriter interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - 1.3.0-waylay
   pull_request:
-    branches:
-      - 1.3.0-waylay
 
 jobs:
   build:

--- a/src/main/java/org/kairosdb/core/datapoints/StringDataPoint.java
+++ b/src/main/java/org/kairosdb/core/datapoints/StringDataPoint.java
@@ -25,9 +25,10 @@ public class StringDataPoint extends DataPointHelper
 	@Override
 	public void writeValueToBuffer(DataOutput buffer) throws IOException
 	{
-		if (buffer instanceof org.kairosdb.util.KDataOutput)
+		if (buffer instanceof org.kairosdb.util.LongUTFWriter)
 		{
-			((org.kairosdb.util.KDataOutput) buffer).writeUTFLong(m_value);
+			// Use extended format for proper UTF-8 encoding and large string support
+			((org.kairosdb.util.LongUTFWriter) buffer).writeUTFLong(m_value);
 		}
 		else
 		{

--- a/src/main/java/org/kairosdb/util/BufferedDataOutputStream.java
+++ b/src/main/java/org/kairosdb/util/BufferedDataOutputStream.java
@@ -3,11 +3,12 @@ package org.kairosdb.util;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 
 /**
  Created by bhawkins on 12/10/13.
  */
-public class BufferedDataOutputStream extends DataOutputStream
+public class BufferedDataOutputStream extends DataOutputStream implements LongUTFWriter
 {
 	private WrappedOutputStream m_wrappedOutputStream;
 
@@ -33,6 +34,18 @@ public class BufferedDataOutputStream extends DataOutputStream
 	public long getPosition()
 	{
 		return m_wrappedOutputStream.getPosition();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void writeUTFLong(String s) throws IOException
+	{
+		byte[] utf8Bytes = s.getBytes(StandardCharsets.UTF_8);
+		writeShort(0xFFFF);
+		writeInt(utf8Bytes.length);
+		write(utf8Bytes);
 	}
 
 	private static class WrappedOutputStream extends OutputStream

--- a/src/main/java/org/kairosdb/util/ByteBufferDataInput.java
+++ b/src/main/java/org/kairosdb/util/ByteBufferDataInput.java
@@ -122,7 +122,7 @@ public class ByteBufferDataInput implements KDataInput
 	 * <ul>
 	 *   <li>New format: 0xFFFF marker + 4-byte length + raw UTF-8</li>
 	 *   <li>Legacy format: 4-byte length (starting with 0x0000) + raw UTF-8</li>
-	 *   <li>Old format: 2-byte length + UTF-8 bytes</li>
+	 *   <li>Old format: 2-byte length + UTF-8 bytes (from DataOutputStream.writeUTF)</li>
 	 * </ul>
 	 */
 	@Override
@@ -133,32 +133,52 @@ public class ByteBufferDataInput implements KDataInput
 			throw new IOException("Not enough bytes to read string length");
 		}
 		
+		int savedPosition = m_buffer.position();
 		int firstTwoBytes = readUnsignedShort();
 		
 		if (firstTwoBytes == 0xFFFF)
 		{
-			// New format: 0xFFFF marker + 4-byte length + raw UTF-8
-			int length = readInt();
-			if (length < 0)
+			// Could be new format marker OR old format with length=65535
+			if (m_buffer.remaining() >= 4)
 			{
-				throw new IOException("Invalid string length: " + length);
+				int possibleLength = readInt();
+				if (possibleLength >= 0 && possibleLength <= m_buffer.remaining())
+				{
+					// New format: marker + 4-byte length + raw UTF-8
+					byte[] bytes = new byte[possibleLength];
+					readFully(bytes);
+					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+				}
 			}
-			byte[] bytes = new byte[length];
+			// Fall back to old format: 0xFFFF means length=65535
+			m_buffer.position(savedPosition + 2);
+			byte[] bytes = new byte[65535];
 			readFully(bytes);
 			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
 		else if (firstTwoBytes == 0x0000)
 		{
-			// Legacy format: 4-byte length starting with 0x0000
-			int nextTwoBytes = readUnsignedShort();
-			if (nextTwoBytes == 0)
+			// Could be legacy format OR old format empty string
+			if (m_buffer.remaining() >= 2)
 			{
-				return "";
+				int nextTwoBytes = readUnsignedShort();
+				if (nextTwoBytes == 0)
+				{
+					// Empty string (works for both legacy and old format)
+					return "";
+				}
+				if (nextTwoBytes <= m_buffer.remaining())
+				{
+					// Legacy format: 4-byte length (0x0000 + nextTwoBytes)
+					byte[] bytes = new byte[nextTwoBytes];
+					readFully(bytes);
+					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+				}
+				// Length doesn't fit, revert and treat as old format
+				m_buffer.position(savedPosition + 2);
 			}
-			int length = nextTwoBytes;
-			byte[] bytes = new byte[length];
-			readFully(bytes);
-			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+			// Old format empty string
+			return "";
 		}
 		else
 		{

--- a/src/main/java/org/kairosdb/util/ByteBufferDataInput.java
+++ b/src/main/java/org/kairosdb/util/ByteBufferDataInput.java
@@ -117,59 +117,53 @@ public class ByteBufferDataInput implements KDataInput
 		return DataInputStream.readUTF(this);
 	}
 
+	/**
+	 * Reads a string in one of three formats for backward compatibility:
+	 * <ul>
+	 *   <li>New format: 0xFFFF marker + 4-byte length + raw UTF-8</li>
+	 *   <li>Legacy format: 4-byte length (starting with 0x0000) + raw UTF-8</li>
+	 *   <li>Old format: 2-byte length + UTF-8 bytes</li>
+	 * </ul>
+	 */
 	@Override
 	public String readUTFLong() throws IOException
 	{
-		int savedPosition = m_buffer.position();
-		int totalRemaining = m_buffer.remaining();
-		
-		if (totalRemaining < 2)
+		if (m_buffer.remaining() < 2)
 		{
 			throw new IOException("Not enough bytes to read string length");
 		}
 		
-		if (totalRemaining >= 4)
+		int firstTwoBytes = readUnsignedShort();
+		
+		if (firstTwoBytes == 0xFFFF)
 		{
-			int newLength = readInt();
-			
-			if (newLength >= 0 && newLength <= Integer.MAX_VALUE - 10)
+			// New format: 0xFFFF marker + 4-byte length + raw UTF-8
+			int length = readInt();
+			if (length < 0)
 			{
-				int remainingAfterLength = m_buffer.remaining();
-				if (remainingAfterLength >= newLength)
-				{
-					byte[] bytes = new byte[newLength];
-					readFully(bytes);
-					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
-				}
-				m_buffer.position(savedPosition);
+				throw new IOException("Invalid string length: " + length);
 			}
-			else
-			{
-				m_buffer.position(savedPosition);
-			}
+			byte[] bytes = new byte[length];
+			readFully(bytes);
+			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
-		
-		m_buffer.position(savedPosition);
-		int oldLength = readUnsignedShort();
-		int remainingAfterLength = m_buffer.remaining();
-		
-		if (oldLength <= 65535 && remainingAfterLength == oldLength)
+		else if (firstTwoBytes == 0x0000)
 		{
-			byte[] bytes = new byte[oldLength];
+			// Legacy format: 4-byte length starting with 0x0000
+			int nextTwoBytes = readUnsignedShort();
+			if (nextTwoBytes == 0)
+			{
+				return "";
+			}
+			int length = nextTwoBytes;
+			byte[] bytes = new byte[length];
 			readFully(bytes);
 			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
 		else
 		{
-			m_buffer.position(savedPosition);
-			int newLength = readInt();
-			
-			if (newLength < 0 || newLength > Integer.MAX_VALUE - 10)
-			{
-				throw new IOException("Invalid string length: " + newLength);
-			}
-			
-			byte[] bytes = new byte[newLength];
+			// Old format: 2-byte length + UTF-8 bytes
+			byte[] bytes = new byte[firstTwoBytes];
 			readFully(bytes);
 			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}

--- a/src/main/java/org/kairosdb/util/KDataInputStream.java
+++ b/src/main/java/org/kairosdb/util/KDataInputStream.java
@@ -20,38 +20,62 @@ public class KDataInputStream extends DataInputStream implements KDataInput
 	 * <ul>
 	 *   <li>New format: 0xFFFF marker + 4-byte length + raw UTF-8</li>
 	 *   <li>Legacy format: 4-byte length (starting with 0x0000) + raw UTF-8</li>
-	 *   <li>Old format: 2-byte length + UTF-8 bytes</li>
+	 *   <li>Old format: 2-byte length + UTF-8 bytes (from DataOutputStream.writeUTF)</li>
 	 * </ul>
 	 */
 	@Override
 	public String readUTFLong() throws IOException
 	{
+		mark(70000); // Mark to allow reset if format detection fails
 		int firstTwoBytes = readUnsignedShort();
 		
 		if (firstTwoBytes == 0xFFFF)
 		{
-			// New format: 0xFFFF marker + 4-byte length + raw UTF-8
-			int length = readInt();
-			if (length < 0)
+			// Could be new format marker OR old format with length=65535
+			try
 			{
-				throw new IOException("Invalid string length: " + length);
+				int possibleLength = readInt();
+				if (possibleLength >= 0 && possibleLength <= 10_000_000) // Sanity check
+				{
+					byte[] bytes = new byte[possibleLength];
+					readFully(bytes);
+					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+				}
 			}
-			byte[] bytes = new byte[length];
+			catch (Exception e)
+			{
+				// Fall through to old format handling
+			}
+			// Fall back to old format: 0xFFFF means length=65535
+			reset();
+			readUnsignedShort(); // Skip the 0xFFFF we already read
+			byte[] bytes = new byte[65535];
 			readFully(bytes);
 			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
 		else if (firstTwoBytes == 0x0000)
 		{
-			// Legacy format: 4-byte length starting with 0x0000
-			int nextTwoBytes = readUnsignedShort();
-			if (nextTwoBytes == 0)
+			// Could be legacy format OR old format empty string
+			try
 			{
+				int nextTwoBytes = readUnsignedShort();
+				if (nextTwoBytes == 0)
+				{
+					// Empty string (works for both legacy and old format)
+					return "";
+				}
+				// Legacy format: 4-byte length (0x0000 + nextTwoBytes)
+				byte[] bytes = new byte[nextTwoBytes];
+				readFully(bytes);
+				return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+			}
+			catch (Exception e)
+			{
+				// Not enough bytes - must be old format empty string
+				reset();
+				readUnsignedShort(); // Skip the 0x0000
 				return "";
 			}
-			int length = nextTwoBytes;
-			byte[] bytes = new byte[length];
-			readFully(bytes);
-			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
 		else
 		{

--- a/src/main/java/org/kairosdb/util/KDataInputStream.java
+++ b/src/main/java/org/kairosdb/util/KDataInputStream.java
@@ -15,74 +15,50 @@ public class KDataInputStream extends DataInputStream implements KDataInput
 		super(in);
 	}
 
+	/**
+	 * Reads a string in one of three formats for backward compatibility:
+	 * <ul>
+	 *   <li>New format: 0xFFFF marker + 4-byte length + raw UTF-8</li>
+	 *   <li>Legacy format: 4-byte length (starting with 0x0000) + raw UTF-8</li>
+	 *   <li>Old format: 2-byte length + UTF-8 bytes</li>
+	 * </ul>
+	 */
 	@Override
 	public String readUTFLong() throws IOException
 	{
-		mark(65537);
+		int firstTwoBytes = readUnsignedShort();
 		
-		try
+		if (firstTwoBytes == 0xFFFF)
 		{
-			int newLength = readInt();
-			
-			if (newLength < 0 || newLength > Integer.MAX_VALUE - 10)
+			// New format: 0xFFFF marker + 4-byte length + raw UTF-8
+			int length = readInt();
+			if (length < 0)
 			{
-				reset();
-				int oldLength = readUnsignedShort();
-				if (oldLength <= 65535)
-				{
-					byte[] bytes = new byte[oldLength];
-					readFully(bytes);
-					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
-				}
-				throw new IOException("Invalid string length: " + newLength);
+				throw new IOException("Invalid string length: " + length);
 			}
-			
-			try
-			{
-				byte[] bytes = new byte[newLength];
-				readFully(bytes);
-				return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
-			}
-			catch (IOException e)
-			{
-				reset();
-				int oldLength = readUnsignedShort();
-				if (oldLength <= 65535)
-				{
-					byte[] bytes = new byte[oldLength];
-					readFully(bytes);
-					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
-				}
-				throw new IOException("Failed to read string", e);
-			}
+			byte[] bytes = new byte[length];
+			readFully(bytes);
+			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
-		catch (Exception e)
+		else if (firstTwoBytes == 0x0000)
 		{
-			try
+			// Legacy format: 4-byte length starting with 0x0000
+			int nextTwoBytes = readUnsignedShort();
+			if (nextTwoBytes == 0)
 			{
-				reset();
+				return "";
 			}
-			catch (IOException resetException)
-			{
-				throw new IOException("Failed to read string and reset stream", e);
-			}
-			
-			try
-			{
-				int oldLength = readUnsignedShort();
-				if (oldLength <= 65535)
-				{
-					byte[] bytes = new byte[oldLength];
-					readFully(bytes);
-					return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
-				}
-			}
-			catch (Exception oldFormatException)
-			{
-				throw new IOException("Failed to read string in both formats", e);
-			}
-			
-			throw new IOException("Failed to read string", e);
+			int length = nextTwoBytes;
+			byte[] bytes = new byte[length];
+			readFully(bytes);
+			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+		}
+		else
+		{
+			// Old format: 2-byte length + UTF-8 bytes
+			byte[] bytes = new byte[firstTwoBytes];
+			readFully(bytes);
+			return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
 		}
 	}
 }

--- a/src/main/java/org/kairosdb/util/KDataOutput.java
+++ b/src/main/java/org/kairosdb/util/KDataOutput.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 /**
  Created by bhawkins on 12/10/13.
  */
-public class KDataOutput implements DataOutput
+public class KDataOutput implements DataOutput, LongUTFWriter
 {
 	private ByteArrayOutputStream m_arrayOutputStream;
 	private DataOutputStream m_dataOutputStream;
@@ -109,9 +109,14 @@ public class KDataOutput implements DataOutput
 		m_dataOutputStream.writeUTF(s);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void writeUTFLong(String s) throws IOException
 	{
 		byte[] utf8Bytes = s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+		m_dataOutputStream.writeShort(0xFFFF);
 		m_dataOutputStream.writeInt(utf8Bytes.length);
 		m_dataOutputStream.write(utf8Bytes);
 	}

--- a/src/main/java/org/kairosdb/util/LongUTFWriter.java
+++ b/src/main/java/org/kairosdb/util/LongUTFWriter.java
@@ -1,0 +1,23 @@
+package org.kairosdb.util;
+
+import java.io.IOException;
+
+/**
+ * Interface for writing strings in extended UTF format that supports strings larger than 65535 bytes
+ * and uses standard UTF-8 encoding (not Java's modified UTF-8).
+ * 
+ * Format: 0xFFFF marker (2 bytes) + length (4 bytes) + raw UTF-8 bytes
+ */
+public interface LongUTFWriter
+{
+	/**
+	 * Writes a string in extended format for strings > 65535 bytes.
+	 * Uses standard UTF-8 encoding, which properly handles all Unicode characters
+	 * including 4-byte characters like emojis.
+	 *
+	 * @param s the string to write
+	 * @throws IOException if an I/O error occurs
+	 */
+	void writeUTFLong(String s) throws IOException;
+}
+

--- a/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
@@ -24,6 +24,8 @@ import org.kairosdb.core.datapoints.IngestionTimestampDataPoint;
 import org.kairosdb.core.datapoints.LegacyDataPointFactory;
 import org.kairosdb.core.datapoints.LegacyDoubleDataPoint;
 import org.kairosdb.core.datapoints.LegacyLongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
+import org.kairosdb.core.datapoints.StringDataPointFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -310,5 +312,182 @@ public class CachedSearchResultTest
 		}
 	}
 
+	@Test
+	public void test_StringDataPoint_Roundtrip() throws IOException
+	{
+		String tempFile = System.getProperty("java.io.tmpdir") + "/baseFile_string";
+		CachedSearchResult csResult =
+				CachedSearchResult.createCachedSearchResult("metric_string", tempFile, dataPointFactory, true);
 
+		long now = System.currentTimeMillis();
+
+		SortedMap<String, String> tags = new TreeMap<>();
+		tags.put("host", "A");
+		QueryCallback.DataPointWriter dataPointWriter = csResult.startDataPointSet(StringDataPointFactory.DST_STRING, tags);
+
+		String[] testStrings = {
+				"Simple string",
+				"Unicode: 你好世界 🌍",
+				"",
+				"Special chars: \t\n\r\"'\\",
+		};
+
+		for (int i = 0; i < testStrings.length; i++)
+		{
+			dataPointWriter.addDataPoint(new StringDataPoint(now + i, testStrings[i]));
+		}
+
+		dataPointWriter.close();
+
+		List<DataPointRow> rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		DataPointRow row = rows.get(0);
+
+		for (int i = 0; i < testStrings.length; i++)
+		{
+			assertThat(row.hasNext(), equalTo(true));
+			DataPoint dp = row.next();
+			assertThat(dp instanceof StringDataPoint, equalTo(true));
+			StringDataPoint sdp = (StringDataPoint) dp;
+			assertThat(sdp.getValue(), equalTo(testStrings[i]));
+			assertThat(sdp.getTimestamp(), equalTo(now + i));
+		}
+
+		assertThat(row.hasNext(), equalTo(false));
+		row.close();
+		csResult.close();
+
+		// Re-open cached file and verify data survives disk roundtrip
+		csResult = CachedSearchResult.openCachedSearchResult("metric_string", tempFile, 100, dataPointFactory, true);
+		rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		row = rows.get(0);
+
+		for (int i = 0; i < testStrings.length; i++)
+		{
+			assertThat(row.hasNext(), equalTo(true));
+			DataPoint dp = row.next();
+			assertThat(dp instanceof StringDataPoint, equalTo(true));
+			StringDataPoint sdp = (StringDataPoint) dp;
+			assertThat(sdp.getValue(), equalTo(testStrings[i]));
+			assertThat(sdp.getTimestamp(), equalTo(now + i));
+		}
+
+		assertThat(row.hasNext(), equalTo(false));
+		row.close();
+		csResult.close();
+	}
+
+	@Test
+	public void test_StringDataPoint_LargeStrings() throws IOException
+	{
+		String tempFile = System.getProperty("java.io.tmpdir") + "/baseFile_large_string";
+		CachedSearchResult csResult =
+				CachedSearchResult.createCachedSearchResult("metric_large_string", tempFile, dataPointFactory, true);
+
+		long now = System.currentTimeMillis();
+
+		SortedMap<String, String> tags = new TreeMap<>();
+		tags.put("host", "A");
+		QueryCallback.DataPointWriter dataPointWriter = csResult.startDataPointSet(StringDataPointFactory.DST_STRING, tags);
+
+		// Create large strings that exceed the old writeUTF limit (65535 bytes)
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 100000; i++)
+		{
+			sb.append("A");
+		}
+		String largeString = sb.toString();  // 100KB string
+
+		// Also test a string with unicode that results in large UTF-8
+		StringBuilder unicodeSb = new StringBuilder();
+		for (int i = 0; i < 30000; i++)
+		{
+			unicodeSb.append("日");  // 3 bytes in UTF-8
+		}
+		String largeUnicodeString = unicodeSb.toString();  // ~90KB in UTF-8
+
+		dataPointWriter.addDataPoint(new StringDataPoint(now, largeString));
+		dataPointWriter.addDataPoint(new StringDataPoint(now + 1, largeUnicodeString));
+		dataPointWriter.close();
+
+		List<DataPointRow> rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		DataPointRow row = rows.get(0);
+
+		// Verify large ASCII string
+		assertThat(row.hasNext(), equalTo(true));
+		DataPoint dp1 = row.next();
+		assertThat(dp1 instanceof StringDataPoint, equalTo(true));
+		assertThat(((StringDataPoint) dp1).getValue(), equalTo(largeString));
+
+		// Verify large Unicode string
+		assertThat(row.hasNext(), equalTo(true));
+		DataPoint dp2 = row.next();
+		assertThat(dp2 instanceof StringDataPoint, equalTo(true));
+		assertThat(((StringDataPoint) dp2).getValue(), equalTo(largeUnicodeString));
+
+		assertThat(row.hasNext(), equalTo(false));
+		row.close();
+		csResult.close();
+
+		// Re-open cached file and verify large strings survive disk roundtrip
+		csResult = CachedSearchResult.openCachedSearchResult("metric_large_string", tempFile, 100, dataPointFactory, true);
+		rows = csResult.getRows();
+		assertEquals(1, rows.size());
+
+		row = rows.get(0);
+
+		assertThat(row.hasNext(), equalTo(true));
+		dp1 = row.next();
+		assertThat(((StringDataPoint) dp1).getValue(), equalTo(largeString));
+
+		assertThat(row.hasNext(), equalTo(true));
+		dp2 = row.next();
+		assertThat(((StringDataPoint) dp2).getValue(), equalTo(largeUnicodeString));
+
+		assertThat(row.hasNext(), equalTo(false));
+		row.close();
+		csResult.close();
+	}
+
+	@Test
+	public void test_StringDataPoint_ManyStringsBeyondBufferSize() throws IOException
+	{
+		String tempFile = System.getProperty("java.io.tmpdir") + "/baseFile_many_strings";
+		CachedSearchResult csResult = CachedSearchResult.createCachedSearchResult(
+				"metric_many_strings", tempFile, dataPointFactory, true);
+
+		// Create many strings to exceed buffer size and test buffer flushing
+		int numberOfDataPoints = CachedSearchResult.WRITE_BUFFER_SIZE / 10;  // Ensure we exceed buffer
+		QueryCallback.DataPointWriter dataPointWriter = csResult.startDataPointSet(
+				StringDataPointFactory.DST_STRING, Collections.<String, String>emptySortedMap());
+
+		long now = System.currentTimeMillis();
+		for (int i = 0; i < numberOfDataPoints; i++)
+		{
+			dataPointWriter.addDataPoint(new StringDataPoint(now + i, "Value_" + i));
+		}
+
+		dataPointWriter.close();
+
+		List<DataPointRow> rows = csResult.getRows();
+		DataPointRow row = rows.iterator().next();
+
+		int count = 0;
+		while (row.hasNext())
+		{
+			DataPoint dataPoint = row.next();
+			assertThat(dataPoint instanceof StringDataPoint, equalTo(true));
+			assertThat(((StringDataPoint) dataPoint).getValue(), equalTo("Value_" + count));
+			count++;
+		}
+
+		assertThat(count, equalTo(numberOfDataPoints));
+		row.close();
+		csResult.close();
+	}
 }

--- a/src/test/java/org/kairosdb/util/ByteBufferDataInputTest.java
+++ b/src/test/java/org/kairosdb/util/ByteBufferDataInputTest.java
@@ -189,8 +189,9 @@ public class ByteBufferDataInputTest
 	@Test
 	public void test_readUTFLong_backwardCompatibility_oldFormat_maxSize() throws IOException
 	{
+		// Use 65534 instead of 65535 to avoid collision with 0xFFFF marker
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < 65535; i++)
+		for (int i = 0; i < 65534; i++)
 		{
 			sb.append('A');
 		}
@@ -204,7 +205,7 @@ public class ByteBufferDataInputTest
 				ByteBuffer.wrap(baos.toByteArray()));
 		String result = dataInput.readUTFLong();
 		assertEquals(testString, result);
-		assertEquals(65535, result.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
+		assertEquals(65534, result.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
 	}
 
 	@Test
@@ -233,5 +234,37 @@ public class ByteBufferDataInputTest
 				ByteBuffer.wrap(output.getBytes()));
 		String result = dataInput.readUTFLong();
 		assertEquals(testString, result);
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_smallString() throws IOException
+	{
+		// Simulates legacy format from commit 0866c3fe (4-byte length, no marker)
+		String testString = "Legacy format test";
+		byte[] utf8Bytes = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+		dos.writeInt(utf8Bytes.length);  // 4-byte length (no marker)
+		dos.write(utf8Bytes);
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(baos.toByteArray()));
+		String result = dataInput.readUTFLong();
+		assertEquals(testString, result);
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_emptyString() throws IOException
+	{
+		// Legacy format with empty string
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+		dos.writeInt(0);  // 4-byte length = 0
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(baos.toByteArray()));
+		String result = dataInput.readUTFLong();
+		assertEquals("", result);
 	}
 }

--- a/src/test/java/org/kairosdb/util/ByteBufferDataInputTest.java
+++ b/src/test/java/org/kairosdb/util/ByteBufferDataInputTest.java
@@ -267,4 +267,98 @@ public class ByteBufferDataInputTest
 		String result = dataInput.readUTFLong();
 		assertEquals("", result);
 	}
+
+	@Test
+	public void test_readUTFLong_oldFormat_emptyString() throws IOException
+	{
+		// Old format empty string - just 2 bytes: 0x0000
+		// This tests the edge case where old writeUTF empty string could be
+		// confused with legacy format (which also starts with 0x0000)
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+		dos.writeUTF("");  // Old format: 2-byte length = 0
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(baos.toByteArray()));
+		String result = dataInput.readUTFLong();
+		assertEquals("", result);
+	}
+
+	@Test
+	public void test_readUTFLong_oldFormat_maxLength65535() throws IOException
+	{
+		// Old format with exactly 65535 bytes - length is 0xFFFF
+		// This tests the edge case where 0xFFFF length could be confused with new format marker
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 65535; i++)
+		{
+			sb.append('A');
+		}
+		String testString = sb.toString();
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+		dos.writeUTF(testString);  // Old format with 0xFFFF length
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(baos.toByteArray()));
+		String result = dataInput.readUTFLong();
+		assertEquals(testString, result);
+		assertEquals(65535, result.length());
+	}
+
+	@Test
+	public void test_readUTFLong_mixedFormats_allThree() throws IOException
+	{
+		// Test reading all three formats in sequence
+		java.io.ByteArrayOutputStream combined = new java.io.ByteArrayOutputStream();
+
+		// 1. Old format string
+		java.io.ByteArrayOutputStream oldFormatBaos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream oldDos = new java.io.DataOutputStream(oldFormatBaos);
+		oldDos.writeUTF("Old format");
+		combined.write(oldFormatBaos.toByteArray());
+
+		// 2. Legacy format string (4-byte length, no marker)
+		java.io.ByteArrayOutputStream legacyBaos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream legacyDos = new java.io.DataOutputStream(legacyBaos);
+		byte[] legacyBytes = "Legacy format".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+		legacyDos.writeInt(legacyBytes.length);
+		legacyDos.write(legacyBytes);
+		combined.write(legacyBaos.toByteArray());
+
+		// 3. New format string (0xFFFF marker + 4-byte length)
+		KDataOutput newOutput = new KDataOutput();
+		newOutput.writeUTFLong("New format");
+		combined.write(newOutput.getBytes());
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(combined.toByteArray()));
+		assertEquals("Old format", dataInput.readUTFLong());
+		assertEquals("Legacy format", dataInput.readUTFLong());
+		assertEquals("New format", dataInput.readUTFLong());
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_largeString() throws IOException
+	{
+		// Legacy format with large string
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 10000; i++)
+		{
+			sb.append('X');
+		}
+		String testString = sb.toString();
+		byte[] utf8Bytes = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+		dos.writeInt(utf8Bytes.length);  // 4-byte length
+		dos.write(utf8Bytes);
+
+		ByteBufferDataInput dataInput = new ByteBufferDataInput(
+				ByteBuffer.wrap(baos.toByteArray()));
+		String result = dataInput.readUTFLong();
+		assertEquals(testString, result);
+	}
 }

--- a/src/test/java/org/kairosdb/util/KDataInputStreamTest.java
+++ b/src/test/java/org/kairosdb/util/KDataInputStreamTest.java
@@ -138,8 +138,9 @@ public class KDataInputStreamTest
 	@Test
 	public void test_readUTFLong_backwardCompatibility_oldFormat_maxSize() throws IOException
 	{
+		// Use 65534 instead of 65535 to avoid collision with 0xFFFF marker
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < 65535; i++)
+		for (int i = 0; i < 65534; i++)
 		{
 			sb.append('A');
 		}
@@ -153,7 +154,7 @@ public class KDataInputStreamTest
 				new ByteArrayInputStream(baos.toByteArray()));
 		String result = input.readUTFLong();
 		assertEquals(testString, result);
-		assertEquals(65535, result.getBytes(StandardCharsets.UTF_8).length);
+		assertEquals(65534, result.getBytes(StandardCharsets.UTF_8).length);
 	}
 
 	@Test
@@ -204,6 +205,39 @@ public class KDataInputStreamTest
 				new ByteArrayInputStream(combined));
 		assertEquals("Old format string", input.readUTFLong());
 		assertEquals("New format string", input.readUTFLong());
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_smallString() throws IOException
+	{
+		// Simulates legacy format from commit 0866c3fe (4-byte length, no marker)
+		// This should be detected via the 0x0000 high bytes in the length
+		String testString = "Legacy format test";
+		byte[] utf8Bytes = testString.getBytes(StandardCharsets.UTF_8);
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		DataOutputStream dos = new DataOutputStream(baos);
+		dos.writeInt(utf8Bytes.length);  // 4-byte length (no marker)
+		dos.write(utf8Bytes);
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(baos.toByteArray()));
+		String result = input.readUTFLong();
+		assertEquals(testString, result);
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_emptyString() throws IOException
+	{
+		// Legacy format with empty string
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		DataOutputStream dos = new DataOutputStream(baos);
+		dos.writeInt(0);  // 4-byte length = 0
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(baos.toByteArray()));
+		String result = input.readUTFLong();
+		assertEquals("", result);
 	}
 }
 

--- a/src/test/java/org/kairosdb/util/KDataInputStreamTest.java
+++ b/src/test/java/org/kairosdb/util/KDataInputStreamTest.java
@@ -239,5 +239,101 @@ public class KDataInputStreamTest
 		String result = input.readUTFLong();
 		assertEquals("", result);
 	}
+
+	@Test
+	public void test_readUTFLong_oldFormat_emptyString() throws IOException
+	{
+		// Old format empty string - just 2 bytes: 0x0000
+		// This tests the edge case where old writeUTF empty string could be
+		// confused with legacy format (which also starts with 0x0000)
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		DataOutputStream dos = new DataOutputStream(baos);
+		dos.writeUTF("");  // Old format: 2-byte length = 0
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(baos.toByteArray()));
+		String result = input.readUTFLong();
+		assertEquals("", result);
+	}
+
+	@Test
+	public void test_readUTFLong_oldFormat_maxLength65535() throws IOException
+	{
+		// Old format with exactly 65535 bytes - length is 0xFFFF
+		// This tests the edge case where 0xFFFF length could be confused with new format marker
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 65535; i++)
+		{
+			sb.append('A');
+		}
+		String testString = sb.toString();
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		DataOutputStream dos = new DataOutputStream(baos);
+		dos.writeUTF(testString);  // Old format with 0xFFFF length
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(baos.toByteArray()));
+		String result = input.readUTFLong();
+		assertEquals(testString, result);
+		assertEquals(65535, result.length());
+	}
+
+	@Test
+	public void test_readUTFLong_mixedFormats_allThree() throws IOException
+	{
+		// Test reading all three formats in sequence
+		java.io.ByteArrayOutputStream combined = new java.io.ByteArrayOutputStream();
+
+		// 1. Old format string
+		java.io.ByteArrayOutputStream oldFormatBaos = new java.io.ByteArrayOutputStream();
+		DataOutputStream oldDos = new DataOutputStream(oldFormatBaos);
+		oldDos.writeUTF("Old format");
+		combined.write(oldFormatBaos.toByteArray());
+
+		// 2. Legacy format string (4-byte length, no marker)
+		java.io.ByteArrayOutputStream legacyBaos = new java.io.ByteArrayOutputStream();
+		DataOutputStream legacyDos = new DataOutputStream(legacyBaos);
+		byte[] legacyBytes = "Legacy format".getBytes(StandardCharsets.UTF_8);
+		legacyDos.writeInt(legacyBytes.length);
+		legacyDos.write(legacyBytes);
+		combined.write(legacyBaos.toByteArray());
+
+		// 3. New format string (0xFFFF marker + 4-byte length)
+		KDataOutput newOutput = new KDataOutput();
+		newOutput.writeUTFLong("New format");
+		combined.write(newOutput.getBytes());
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(combined.toByteArray()));
+		assertEquals("Old format", input.readUTFLong());
+		assertEquals("Legacy format", input.readUTFLong());
+		assertEquals("New format", input.readUTFLong());
+	}
+
+	@Test
+	public void test_readUTFLong_legacyFormat_largeString() throws IOException
+	{
+		// Legacy format with large string (>65535 bytes would have non-zero high bytes)
+		// But since legacy format was only used for strings that exceeded writeUTF limit,
+		// we test with a moderately sized string
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 10000; i++)
+		{
+			sb.append('X');
+		}
+		String testString = sb.toString();
+		byte[] utf8Bytes = testString.getBytes(StandardCharsets.UTF_8);
+
+		java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+		DataOutputStream dos = new DataOutputStream(baos);
+		dos.writeInt(utf8Bytes.length);  // 4-byte length
+		dos.write(utf8Bytes);
+
+		KDataInputStream input = new KDataInputStream(
+				new ByteArrayInputStream(baos.toByteArray()));
+		String result = input.readUTFLong();
+		assertEquals(testString, result);
+	}
 }
 

--- a/src/test/java/org/kairosdb/util/KDataOutputTest.java
+++ b/src/test/java/org/kairosdb/util/KDataOutputTest.java
@@ -19,8 +19,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + UTF-8 encoded string bytes
-		int expectedLength = 4 + testString.getBytes(StandardCharsets.UTF_8).length;
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + UTF-8 encoded string bytes
+		int expectedLength = 6 + testString.getBytes(StandardCharsets.UTF_8).length;
 		assertEquals(expectedLength, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
@@ -36,8 +36,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + 0 bytes
-		assertEquals(4, bytes.length);
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + 0 bytes
+		assertEquals(6, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
 		String result = input.readUTFLong();
@@ -60,8 +60,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + UTF-8 encoded string bytes
-		int expectedLength = 4 + utf8Length;
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + UTF-8 encoded string bytes
+		int expectedLength = 6 + utf8Length;
 		assertEquals(expectedLength, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
@@ -87,8 +87,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + 65535 bytes
-		assertEquals(4 + 65535, bytes.length);
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + 65535 bytes
+		assertEquals(6 + 65535, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
 		String result = input.readUTFLong();
@@ -113,8 +113,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + 100000 bytes
-		assertEquals(4 + 100000, bytes.length);
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + 100000 bytes
+		assertEquals(6 + 100000, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
 		String result = input.readUTFLong();
@@ -139,8 +139,8 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		// 4 bytes (int length) + 200000 bytes
-		assertEquals(4 + 200000, bytes.length);
+		// 2 bytes (0xFFFF marker) + 4 bytes (int length) + 200000 bytes
+		assertEquals(6 + 200000, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
 		String result = input.readUTFLong();
@@ -177,7 +177,7 @@ public class KDataOutputTest
 		output.writeUTFLong(testString);
 
 		byte[] bytes = output.getBytes();
-		assertEquals(4 + utf8Length, bytes.length);
+		assertEquals(6 + utf8Length, bytes.length);
 
 		KDataInput input = KDataInput.createInput(bytes);
 		String result = input.readUTFLong();
@@ -203,7 +203,7 @@ public class KDataOutputTest
 	@Test
 	public void test_writeUTFLong_formatVerification() throws IOException
 	{
-		// 4-byte int length prefix followed by UTF-8 bytes
+		// 2-byte 0xFFFF marker + 4-byte int length prefix followed by UTF-8 bytes
 		String testString = "Test";
 		KDataOutput output = new KDataOutput();
 		output.writeUTFLong(testString);
@@ -211,16 +211,20 @@ public class KDataOutputTest
 		byte[] bytes = output.getBytes();
 		byte[] expectedUtf8 = testString.getBytes(StandardCharsets.UTF_8);
 
-		// First 4 bytes should be the length as int
-		int length = ((bytes[0] & 0xFF) << 24) |
-				((bytes[1] & 0xFF) << 16) |
-				((bytes[2] & 0xFF) << 8) |
-				(bytes[3] & 0xFF);
+		// First 2 bytes should be 0xFFFF marker
+		int marker = ((bytes[0] & 0xFF) << 8) | (bytes[1] & 0xFF);
+		assertEquals(0xFFFF, marker);
+
+		// Next 4 bytes should be the length as int
+		int length = ((bytes[2] & 0xFF) << 24) |
+				((bytes[3] & 0xFF) << 16) |
+				((bytes[4] & 0xFF) << 8) |
+				(bytes[5] & 0xFF);
 		assertEquals(expectedUtf8.length, length);
 
 		// Remaining bytes should be the UTF-8 encoded string
 		byte[] actualUtf8 = new byte[expectedUtf8.length];
-		System.arraycopy(bytes, 4, actualUtf8, 0, expectedUtf8.length);
+		System.arraycopy(bytes, 6, actualUtf8, 0, expectedUtf8.length);
 		assertArrayEquals(expectedUtf8, actualUtf8);
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/waylayio/kairosdb/pull/23

@ramazanyich , I've deployed this manually on prod to test it for real and I see no more issues so I would like to create a new release of kairosdb to make it official.