### PR TITLE
fix: WPPM-3000 harden datapoint row iteration against null values + fail fast with more context provided

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/CachedSearchResult.java
+++ b/src/main/java/org/kairosdb/core/datastore/CachedSearchResult.java
@@ -505,8 +505,6 @@ public class CachedSearchResult implements SearchResult
 		@Override
 		public DataPoint next()
 		{
-			DataPoint ret = null;
-
 			try
 			{
 				//Lazy allocation of buffer to conserve memory when using group by's
@@ -522,42 +520,52 @@ public class CachedSearchResult implements SearchResult
 					{
 						long ingestionTimestamp = m_readBuffer.readLong();
 						DataPoint baseDataPoint = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
-						ret = new IngestionTimestampDataPoint(baseDataPoint, ingestionTimestamp);
+						DataPoint ret = new IngestionTimestampDataPoint(baseDataPoint, ingestionTimestamp);
+						m_dataPointsRead ++;
+						closeReadBufferIfDone();
+						return (ret);
 					}
 					else
 					{
-						ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+						DataPoint ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+						m_dataPointsRead ++;
+						closeReadBufferIfDone();
+						return (ret);
 					}
 				}
 				else
 				{
-					ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+					DataPoint ret = m_dataPointFactory.createDataPoint(m_dataType, timestamp, m_readBuffer);
+					m_dataPointsRead ++;
+					closeReadBufferIfDone();
+					return (ret);
 				}
-
 			}
 			catch (IOException ioe)
 			{
-				logger.error("Error reading next data point.", ioe);
+				throw new IllegalStateException("Error reading next data point for metric '" + m_metricName + "'", ioe);
 			}
+		}
 
-			m_dataPointsRead ++;
-
-			//Clean up buffer.  In cases where we are grouping not all rows are read
-			//at once so this will save memory
-			if (m_dataPointsRead == m_dataPointCount)
+		private void closeReadBufferIfDone()
+		{
+			//Clean up buffer. In cases where we are grouping not all rows are read
+			//at once so this will save memory.
+			if (m_dataPointsRead == m_dataPointCount && m_readBuffer != null)
 			{
 				try
 				{
 					m_readBuffer.close();
+				}
+				catch (IOException ioe)
+				{
+					logger.warn("Unable to close cached datapoint read buffer for metric '{}'", m_metricName, ioe);
+				}
+				finally
+				{
 					m_readBuffer = null;
 				}
-				catch (IOException e)
-				{
-					e.printStackTrace();
-				}
 			}
-
-			return (ret);
 		}
 
 		@Override

--- a/src/main/java/org/kairosdb/core/datastore/DataPointGroupRowWrapper.java
+++ b/src/main/java/org/kairosdb/core/datastore/DataPointGroupRowWrapper.java
@@ -73,6 +73,10 @@ public class DataPointGroupRowWrapper implements DataPointGroup
 	public DataPoint next()
 	{
 		DataPoint dp = m_row.next();
+		if (dp == null)
+		{
+			throw new IllegalStateException("DataPointRow returned null DataPoint for metric '" + m_row.getName() + "'");
+		}
 		dp.setDataPointGroup(this);
 		return (dp);
 	}

--- a/src/test/java/org/kairosdb/core/datastore/DataPointGroupRowWrapperNullDataPointTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/DataPointGroupRowWrapperNullDataPointTest.java
@@ -1,0 +1,97 @@
+package org.kairosdb.core.datastore;
+
+import org.junit.Test;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.datapoints.LongDataPoint;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+
+public class DataPointGroupRowWrapperNullDataPointTest
+{
+	@Test
+	public void next_throws_when_wrapped_row_returns_null_data_point()
+	{
+		DataPointRow brokenRow = new DataPointRow()
+		{
+			private int index = 0;
+
+			@Override
+			public String getName()
+			{
+				return "metric.name";
+			}
+
+			@Override
+			public String getDatastoreType()
+			{
+				return "long";
+			}
+
+			@Override
+			public Set<String> getTagNames()
+			{
+				return Collections.singleton("host");
+			}
+
+			@Override
+			public String getTagValue(String tag)
+			{
+				return "srv-1";
+			}
+
+			@Override
+			public void close()
+			{
+			}
+
+			@Override
+			public int getDataPointCount()
+			{
+				return 2;
+			}
+
+			@Override
+			public boolean hasNext()
+			{
+				return index < 2;
+			}
+
+			@Override
+			public DataPoint next()
+			{
+				index++;
+				if (index == 1)
+				{
+					return new LongDataPoint(1000L, 42L);
+				}
+				return null;
+			}
+
+			@Override
+			public void remove()
+			{
+			}
+		};
+
+		DataPointGroupRowWrapper wrappedRow = new DataPointGroupRowWrapper(brokenRow);
+		SortingDataPointGroup sorted = new SortingDataPointGroup("metric.name", Order.ASC);
+		sorted.addIterator(wrappedRow);
+
+		try
+		{
+			sorted.next();
+			fail("Expected IllegalStateException when DataPointRow returns null");
+		}
+		catch (IllegalStateException ise)
+		{
+			assertThat(ise.getMessage(), containsString("DataPointRow returned null DataPoint"));
+			assertThat(ise.getMessage(), containsString("metric.name"));
+		}
+	}
+}


### PR DESCRIPTION
Addresses WPPM-3000

- fixes NPE by enforcing a non-null DataPoint contract in `DataPointGroupRowWrapper` (throwing `IllegalStateException` with metric context)
-  updates `CachedSearchResult` to throw on read failures instead of returning null