### PR TITLE
security: upgrade Jetty 12.0.32 and Jersey 3.1.10 to fix critical CVEs (SNYK-JAVA-ORGCODEHAUSPLEXUS-31522 and SNYK-JAVA-ORGGLASSFISHJERSEYCORE-14049172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![KairosDB](webroot/img/kairosdb.png)
-[![Build Status](https://travis-ci.org/kairosdb/kairosdb.svg?branch=develop)](https://travis-ci.org/kairosdb/kairosdb)
+[![Build](https://github.com/waylayio/kairosdb/actions/workflows/build.yml/badge.svg?branch=2.0.0-waylay)](https://github.com/waylayio/kairosdb/actions/workflows/build.yml?query=branch%3A2.0.0-waylay)
 
 KairosDB is a fast distributed scalable time series database written on top of Cassandra.
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 	<url>http://kairosdb.org</url>
 
 	<properties>
-		<jersey.version>3.1.9</jersey.version>
-		<jetty.version>12.0.16</jetty.version>
+		<jersey.version>3.1.10</jersey.version>
+		<jetty.version>12.0.32</jetty.version>
 		<jackson.version>2.18.2</jackson.version>
 	</properties>
 


### PR DESCRIPTION
```
✗ Shell Command Injection [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31522] in org.codehaus.plexus:plexus-utils@1.5.1
    introduced by org.codehaus.plexus:plexus-utils@1.5.1
```

```
✗ Race Condition [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-14049172] in org.glassfish.jersey.core:jersey-client@3.1.9
    introduced by org.glassfish.jersey.core:jersey-client@3.1.9
```