### PR TITLE
fix: remove unused modernizer-maven-plugin to eliminate vulnerable plexus-utils transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,12 +323,6 @@
 			<artifactId>jakarta.inject-api</artifactId>
 			<version>2.0.1</version>
 		</dependency>
-
-		<dependency>
-			<groupId>org.gaul</groupId>
-			<artifactId>modernizer-maven-plugin</artifactId>
-			<version>2.0.0</version>
-		</dependency>
 	</dependencies>
 
 	<licenses>


### PR DESCRIPTION
After new scanning with Snyk we get:
```
 Upgrade org.codehaus.plexus:plexus-utils@1.5.1 to org.codehaus.plexus:plexus-utils@3.0.24 to fix
  ✗ Directory Traversal [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521] in org.codehaus.plexus:plexus-utils@1.5.1
    introduced by org.codehaus.plexus:plexus-utils@1.5.1
  ✗ XML External Entity (XXE) Injection [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102] in org.codehaus.plexus:plexus-utils@1.5.1
    introduced by org.codehaus.plexus:plexus-utils@1.5.1
  ✗ Shell Command Injection [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31522] in org.codehaus.plexus:plexus-utils@1.5.1
    introduced by org.codehaus.plexus:plexus-utils@1.5.1
```

Tracing the dependency we find out it's transitive and it's used by `org.gaul:modernizer-maven-plugin`. Although a maven plugin, we have incorrectly used it as compile dependency and on top of that it's not used so we can safely remove it.